### PR TITLE
Fix docs build and pre-commit CI failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         args: ["--verbose"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.1
+    rev: v0.15.20
     hooks:
       - id: ruff
         name: Lint code using ruff; sort and organize imports 
@@ -55,7 +55,7 @@ repos:
         args: ["--fix"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.2.1
+    rev: v0.15.20
     hooks:
       - id: ruff-format
         name: Format code using ruff

--- a/docs/notebooks/motivation.ipynb
+++ b/docs/notebooks/motivation.ipynb
@@ -243,7 +243,7 @@
     "results = simulate_lightcurves(\n",
     "    source,\n",
     "    num_samples=1,\n",
-    "    obstable=obstable,\n",
+    "    survey_info=obstable,\n",
     "    passbands=passbands,\n",
     "    obs_time_window_offset=(-10, 30),  # observer-frame days around t0 (DP1 spans ~-7 to +26)\n",
     "    rng=np.random.default_rng(42),\n",
@@ -263,7 +263,7 @@
     "flux_perfect = lc[\"flux_perfect\"].values\n",
     "\n",
     "print(\n",
-    "    f\"Simulated {len(lc)} observations across bands: { {b: int((obs_bands==b).sum()) for b in BANDS if (obs_bands==b).any()} }\"\n",
+    "    f\"Simulated {len(lc)} observations across bands: { {b: int((obs_bands == b).sum()) for b in BANDS if (obs_bands == b).any()} }\"\n",
     ")\n",
     "print(f\"Peak flux (r-band) ≈ {flux_perfect[obs_bands == 'r'].max():.0f} nJy\")"
    ]
@@ -346,8 +346,7 @@
     "ax_top.set_ylim(-2000, flux_perfect.max() * 1.25)\n",
     "ax_top.set_ylabel(\"Flux (nJy)\")\n",
     "ax_top.set_title(\n",
-    "    f\"Simulated SN Ia (DP1 noise) — SALT3, z={TRUE_PARAMS['z']},\"\n",
-    "    f\" x1={TRUE_PARAMS['x1']}, c={TRUE_PARAMS['c']}\"\n",
+    "    f\"Simulated SN Ia (DP1 noise) — SALT3, z={TRUE_PARAMS['z']}, x1={TRUE_PARAMS['x1']}, c={TRUE_PARAMS['c']}\"\n",
     ")\n",
     "ax_top.legend(ncol=3)\n",
     "\n",
@@ -423,7 +422,7 @@
     "    )\n",
     "\n",
     "print(\"Fit 1 (true errors, photon + ZP):\")\n",
-    "print(f\"  chi2/dof = {result1.chisq:.2f} / {result1.ndof}  (reduced = {result1.chisq/result1.ndof:.2f})\")\n",
+    "print(f\"  chi2/dof = {result1.chisq:.2f} / {result1.ndof}  (reduced = {result1.chisq / result1.ndof:.2f})\")\n",
     "for p, v in zip(result1.param_names, result1.parameters):\n",
     "    e = result1.errors.get(p)  # None for fixed params (z)\n",
     "    truth = TRUE_PARAMS.get(p)\n",
@@ -495,7 +494,7 @@
     "    )\n",
     "\n",
     "print(\"Fit 2 (reported errors, photon noise only):\")\n",
-    "print(f\"  chi2/dof = {result2.chisq:.2f} / {result2.ndof}  (reduced = {result2.chisq/result2.ndof:.2f})\")\n",
+    "print(f\"  chi2/dof = {result2.chisq:.2f} / {result2.ndof}  (reduced = {result2.chisq / result2.ndof:.2f})\")\n",
     "for p, v in zip(result2.param_names, result2.parameters):\n",
     "    e = result2.errors.get(p)\n",
     "    truth = TRUE_PARAMS.get(p)\n",
@@ -616,8 +615,8 @@
     "print(f\"  Reported errors :  Δμ = {dmu2:+.4f} mag\")\n",
     "print()\n",
     "print(f\"Goodness of fit (χ²/dof):\")\n",
-    "print(f\"  True errors     :  {result1.chisq:.1f} / {result1.ndof} = {result1.chisq/result1.ndof:.2f}\")\n",
-    "print(f\"  Reported errors :  {result2.chisq:.1f} / {result2.ndof} = {result2.chisq/result2.ndof:.2f}\")"
+    "print(f\"  True errors     :  {result1.chisq:.1f} / {result1.ndof} = {result1.chisq / result1.ndof:.2f}\")\n",
+    "print(f\"  Reported errors :  {result2.chisq:.1f} / {result2.ndof} = {result2.chisq / result2.ndof:.2f}\")"
    ]
   },
   {

--- a/tests/uncle_val/datasets/test_fake.py
+++ b/tests/uncle_val/datasets/test_fake.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.testing import assert_allclose
+
 from uncle_val.datasets import fake_non_variable_lcs
 from uncle_val.whitening import whiten_data
 

--- a/tests/uncle_val/datasets/test_rubin_dp.py
+++ b/tests/uncle_val/datasets/test_rubin_dp.py
@@ -1,4 +1,5 @@
 import pytest
+
 from uncle_val.datasets.rubin_dp import rubin_dp_catalog_multi_band
 
 

--- a/tests/uncle_val/learning/test_lsdb_dataset.py
+++ b/tests/uncle_val/learning/test_lsdb_dataset.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 from dask.distributed import Client
 from numpy.testing import assert_array_equal
+
 from uncle_val.datasets.fake import fake_non_variable_lcs
 from uncle_val.learning.lsdb_dataset import (
     LSDBIterableDataset,

--- a/tests/uncle_val/learning/test_models.py
+++ b/tests/uncle_val/learning/test_models.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 import torch.optim
 from numpy.testing import assert_allclose
+
 from uncle_val.datasets.fake import fake_non_variable_lcs
 from uncle_val.learning.losses import (
     UncleLoss,

--- a/tests/uncle_val/pipelines/test_feature_importance.py
+++ b/tests/uncle_val/pipelines/test_feature_importance.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from matplotlib.figure import Figure
 from torch.utils.data import DataLoader
+
 from uncle_val.learning.feature_importance import _FlatWrapper, compute_shap_values, plot_shap_summary
 from uncle_val.learning.models import LinearModel
 

--- a/tests/uncle_val/pipelines/test_training_config.py
+++ b/tests/uncle_val/pipelines/test_training_config.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 import torch
+
 from uncle_val.pipelines.training_config import ComputeConfig, TrainingConfig
 
 # --- ComputeConfig ---

--- a/tests/uncle_val/test_variability_detectors.py
+++ b/tests/uncle_val/test_variability_detectors.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from uncle_val.variability_detectors import get_combined_variability_detector
 
 

--- a/tests/uncle_val/test_whitening.py
+++ b/tests/uncle_val/test_whitening.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 import torch
 from numpy.testing import assert_allclose
+
 from uncle_val.whitening import whiten_data, whitening_operator
 
 

--- a/tests/uncle_val/utils/test_hashing.py
+++ b/tests/uncle_val/utils/test_hashing.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from uncle_val.utils.hashing import uniform_hash
 
 

--- a/tests/uncle_val/utils/test_variable.py
+++ b/tests/uncle_val/utils/test_variable.py
@@ -1,5 +1,6 @@
 import pytest
 from dask.distributed import Client
+
 from uncle_val.utils.variable import Variable
 
 


### PR DESCRIPTION
## Summary

Fixes two repo-wide CI failures (present on `main`, affecting every PR including dependabot #87):

1. **`build` (docs)** — `docs/notebooks/motivation.ipynb` called `simulate_lightcurves(obstable=...)`, but LightCurveLynx (installed unpinned via the notebook's own `%pip install`, now 0.4.x) renamed that parameter to `survey_info`. Renamed the argument; `survey_info` still accepts an `ObsTable` (documented backwards-compat), so behavior is unchanged.
2. **`pre-commit-ci`** — applied `ruff-format` to `docs/pre_executed/dp2_object_forcedSource.ipynb` (`PLOT_PARTITION_FRACTION` spacing + a `dask.config.set({...})` block).

Also, as requested, **bumped `ruff-pre-commit` `v0.2.1` → `v0.15.20`** (latest). The only source-code churn from the bump is first-party (`uncle_val`) import grouping in the test files, applied automatically by the newer ruff.

## Verification

- `pre-commit run --all-files` (via commit hooks) passes with the bumped ruff, including lint, format, and unit tests.
- `ruff format --check .` → all files formatted.
- `ruff check` on `*.py`/`*.pyi` → all checks passed.

Note: `motivation.ipynb` was not executed end-to-end locally (it downloads the DP1 CCD-visit table and LSST throughput curves at build time); the API fix is confirmed against the installed LightCurveLynx 0.4.4 signature and docstring.