### PR TITLE
Replace output_root with explicit output_dir run directory

### DIFF
--- a/docs/pre_executed/demo_one-band.ipynb
+++ b/docs/pre_executed/demo_one-band.ipynb
@@ -19,26 +19,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import torch\n",
-    "\n",
-    "N_SRC = 10\n",
-    "BATCH_SIZE = 128\n",
-    "N_LCS = 10_000_000\n",
-    "\n",
-    "DP1_ROOT = \"../../data/dp1\"\n",
-    "# DP1_ROOT = \"/astro/store/epyc3/data3/hats/catalogs/dp1\"\n",
-    "LSDB_WORKERS = 12\n",
-    "# DEVICE = \"cpu\"\n",
-    "# DEVICE = torch.device(\"cuda\", 1)\n",
-    "DEVICE = \"mps\"\n",
-    "\n",
-    "PLOT_MAGS = [18, 21, 25]\n",
-    "\n",
-    "from uncle_val.pipelines.splits import dp1_config\n",
-    "\n",
-    "survey_config = dp1_config(catalog_root=DP1_ROOT, n_src=N_SRC)"
-   ]
+   "source": "from datetime import datetime\nfrom pathlib import Path\n\nimport torch\n\nN_SRC = 10\nBATCH_SIZE = 128\nN_LCS = 10_000_000\n\nDP1_ROOT = \"../../data/dp1\"\n# DP1_ROOT = \"/astro/store/epyc3/data3/hats/catalogs/dp1\"\nLSDB_WORKERS = 12\n# DEVICE = \"cpu\"\n# DEVICE = torch.device(\"cuda\", 1)\nDEVICE = \"mps\"\n\nPLOT_MAGS = [18, 21, 25]\n\nNOW = datetime.now().strftime(\"%Y%m%d_%H%M%S\")\nRUN_DIR = Path(\"./runs\") / NOW\n\nfrom uncle_val.pipelines.splits import dp1_config\n\nsurvey_config = dp1_config(catalog_root=DP1_ROOT, n_src=N_SRC)"
   },
   {
    "cell_type": "code",
@@ -51,32 +32,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "from uncle_val.learning.losses import (\n",
-    "    minus_ln_chi2_prob_loss,\n",
-    "    kl_divergence_whiten_loss,\n",
-    "    epps_pulley_whiten_loss,\n",
-    ")\n",
-    "from uncle_val.pipelines import run_rubin_dp_constant_magerr\n",
-    "\n",
-    "model_path = run_rubin_dp_constant_magerr(\n",
-    "    band=\"r\",\n",
-    "    non_extended_only=True,\n",
-    "    n_workers=LSDB_WORKERS,\n",
-    "    n_lcs=N_LCS,\n",
-    "    loss_fn=epps_pulley_whiten_loss(lmbd=None, soft=None, kind=\"accum\"),\n",
-    "    val_losses={\n",
-    "        \"Total Soften KL\": kl_divergence_whiten_loss(soft=20.0, kind=\"accum\", lmbd=None),\n",
-    "        \"Total Soften -ln(p_χ²)\": minus_ln_chi2_prob_loss(soft=20.0, kind=\"accum\", lmbd=None),\n",
-    "    },\n",
-    "    train_batch_size=BATCH_SIZE,\n",
-    "    val_batch_size=4098,\n",
-    "    start_tfboard=True,\n",
-    "    output_root=\"./runs\",\n",
-    "    device=DEVICE,\n",
-    "    survey_config=survey_config,\n",
-    ")"
-   ]
+   "source": "from uncle_val.learning.losses import (\n    minus_ln_chi2_prob_loss,\n    kl_divergence_whiten_loss,\n    epps_pulley_whiten_loss,\n)\nfrom uncle_val.pipelines import run_rubin_dp_constant_magerr\n\nmodel_path = run_rubin_dp_constant_magerr(\n    band=\"r\",\n    non_extended_only=True,\n    n_workers=LSDB_WORKERS,\n    n_lcs=N_LCS,\n    loss_fn=epps_pulley_whiten_loss(lmbd=None, soft=None, kind=\"accum\"),\n    val_losses={\n        \"Total Soften KL\": kl_divergence_whiten_loss(soft=20.0, kind=\"accum\", lmbd=None),\n        \"Total Soften -ln(p_χ²)\": minus_ln_chi2_prob_loss(soft=20.0, kind=\"accum\", lmbd=None),\n    },\n    train_batch_size=BATCH_SIZE,\n    val_batch_size=4098,\n    start_tfboard=True,\n    output_dir=RUN_DIR,\n    device=DEVICE,\n    survey_config=survey_config,\n)"
   },
   {
    "cell_type": "code",

--- a/src/uncle_val/pipelines/rubin_dp_constant_magerr.py
+++ b/src/uncle_val/pipelines/rubin_dp_constant_magerr.py
@@ -12,7 +12,7 @@ def run_rubin_dp_constant_magerr(
     *,
     band: str,
     non_extended_only: bool,
-    output_root: str | Path,
+    output_dir: str | Path,
     loss_fn: UncleLoss,
     val_losses: dict[str, UncleLoss] | None = None,
     survey_config: SurveyConfig,
@@ -26,8 +26,9 @@ def run_rubin_dp_constant_magerr(
         Passband to train the model on.
     non_extended_only : bool
         Whether to filter out extended sources.
-    output_root : str or Path
-        Where to save the intermediate results.
+    output_dir : str or Path
+        Run directory to save all the outputs to, see
+        :func:`~uncle_val.pipelines.training_loop.training_loop` for details.
     loss_fn : UncleLoss
         Loss function to use, by default soften Χ² is used.
     val_losses : dict[str, UncleLoss] or None
@@ -67,7 +68,7 @@ def run_rubin_dp_constant_magerr(
         model=model,
         loss_fn=loss_fn,
         val_losses=val_losses,
-        output_root=output_root,
+        output_dir=output_dir,
         model_name="constant_magerr",
         survey_config=survey_config,
         training_config=training_config,

--- a/src/uncle_val/pipelines/rubin_dp_linear_flux_err.py
+++ b/src/uncle_val/pipelines/rubin_dp_linear_flux_err.py
@@ -12,7 +12,7 @@ def run_rubin_dp_linear_flux_err(
     *,
     band: str,
     non_extended_only: bool,
-    output_root: str | Path,
+    output_dir: str | Path,
     loss_fn: UncleLoss,
     val_losses: dict[str, UncleLoss] | None = None,
     survey_config: SurveyConfig,
@@ -26,8 +26,9 @@ def run_rubin_dp_linear_flux_err(
         Passband to train the model on.
     non_extended_only : bool
         Whether to filter out extended sources.
-    output_root : str or Path
-        Where to save the intermediate results.
+    output_dir : str or Path
+        Run directory to save all the outputs to, see
+        :func:`~uncle_val.pipelines.training_loop.training_loop` for details.
     loss_fn : UncleLoss
         Loss function to use, by default soften Χ² is used.
     val_losses : dict[str, UncleLoss] or None
@@ -69,7 +70,7 @@ def run_rubin_dp_linear_flux_err(
         model=model,
         loss_fn=loss_fn,
         val_losses=val_losses,
-        output_root=output_root,
+        output_dir=output_dir,
         model_name="linear",
         survey_config=survey_config,
         training_config=training_config,

--- a/src/uncle_val/pipelines/train_on_rubin_dp.py
+++ b/src/uncle_val/pipelines/train_on_rubin_dp.py
@@ -15,7 +15,7 @@ from uncle_val.pipelines.training_loop import training_loop
 def train_on_rubin_dp(
     *,
     model: BaseUncleModel | str | Path,
-    output_root: str | Path,
+    output_dir: str | Path,
     loss_fn: UncleLoss,
     val_losses: dict[str, UncleLoss] | None = None,
     bands: Sequence[str] | None = None,
@@ -30,8 +30,9 @@ def train_on_rubin_dp(
     model : BaseUncleModel or str or Path
         Model instance to train, or a path to a saved model to load and
         continue training from.
-    output_root : str or Path
-        Where to save the intermediate results.
+    output_dir : str or Path
+        Run directory to save all the outputs to, see
+        :func:`~uncle_val.pipelines.training_loop.training_loop` for details.
     loss_fn : UncleLoss
         Loss function to use.
     val_losses : dict[str, UncleLoss] or None
@@ -91,7 +92,7 @@ def train_on_rubin_dp(
         model=model,
         loss_fn=loss_fn,
         val_losses=val_losses,
-        output_root=output_root,
+        output_dir=output_dir,
         model_name=type(model).__name__,
         survey_config=survey_config,
         training_config=training_config,

--- a/src/uncle_val/pipelines/training_loop.py
+++ b/src/uncle_val/pipelines/training_loop.py
@@ -296,4 +296,8 @@ def training_loop(
     model_path = output_dir / f"{model_name}.pt"
     shutil.copy(best_model_path, model_path)
 
+    best_model = torch.load(model_path, weights_only=False, map_location="cpu")
+    best_model.eval()
+    best_model.save_onnx(model_path.with_suffix(".onnx"))
+
     return model_path

--- a/src/uncle_val/pipelines/training_loop.py
+++ b/src/uncle_val/pipelines/training_loop.py
@@ -1,5 +1,4 @@
 import shutil
-from datetime import datetime
 from pathlib import Path
 
 import lsdb
@@ -54,7 +53,7 @@ def training_loop(
     model: BaseUncleModel,
     loss_fn: UncleLoss,
     val_losses: dict[str, UncleLoss],
-    output_root: str | Path,
+    output_dir: str | Path,
     model_name: str,
     survey_config: SurveyConfig,
     training_config: TrainingConfig,
@@ -74,8 +73,11 @@ def training_loop(
     val_losses : dict[str, UncleLoss]
         Extra losses to compute on validation set and record, it maps name to
         loss function.
-    output_root : str or Path
-        Where to save the intermediate results.
+    output_dir : str or Path
+        Run directory to save all the outputs to: model checkpoints, configs,
+        and TensorBoard logs. Its last component is the TensorBoard run name;
+        if requested, TensorBoard is launched on the parent directory, so
+        sibling runs are shown together.
     model_name : str
         Name of the model to use in the output Torch filename.
     survey_config : SurveyConfig
@@ -93,8 +95,7 @@ def training_loop(
 
     device = torch.device(training_config.compute_config.device)
 
-    output_root = Path(output_root)
-    output_dir = Path(output_root) / datetime.now().strftime("%Y-%m-%d_%H-%M")
+    output_dir = Path(output_dir)
     intermediate_model_dir = output_dir / "models"
     intermediate_model_dir.mkdir(parents=True, exist_ok=True)
     tmp_validation_dir = output_dir / "validation"
@@ -103,7 +104,7 @@ def training_loop(
     training_config.to_json(output_dir / "training_config.json")
 
     if training_config.start_tfboard:
-        _launch_tfboard(output_root)
+        _launch_tfboard(output_dir.parent)
     summary_writer = SummaryWriter(log_dir=str(output_dir))
 
     optimizer = Adam(model.parameters(), lr=training_config.lr)


### PR DESCRIPTION
## Summary

- `training_loop`, `train_on_rubin_dp`, `run_rubin_dp_constant_magerr`, and `run_rubin_dp_linear_flux_err` now take a single required `output_dir` (the run directory itself) instead of `output_root` + an internally generated timestamp, so callers always name the run explicitly.
- TensorBoard logs go to `output_dir` (the run shows up under the directory's name) and the auto-launched TensorBoard serves `output_dir.parent`, so sibling runs are still displayed together.
- `dp2_object_forcedSource.ipynb` defines `RUN_DIR = runs/{NOW}` once and saves everything there: model checkpoints, configs, TensorBoard events, and all `make_plots`/feature-importance plots under `runs/{NOW}/plots/`.
- `demo_one-band.ipynb` updated for the renamed argument (note: that notebook is otherwise stale — it still passes `n_workers`/`n_lcs`/etc. directly, which predates the `training_config` API).

## Test plan

- `ruff check` / `ruff format` pass
- Pre-commit unit tests pass
- Full training run of the dp2 notebook to be done on the remote GPU host

🤖 Generated with [Claude Code](https://claude.com/claude-code)