### PR TITLE
Add science forced psfFlux feature for img="diff"

### DIFF
--- a/src/uncle_val/datasets/rubin_dp.py
+++ b/src/uncle_val/datasets/rubin_dp.py
@@ -230,8 +230,14 @@ def _open_catalog(
     match img:
         case "cal":
             phot_col_prefix = "psf"
+            extra_source_cols = []
+            extra_flag_cols = []
         case "diff":
             phot_col_prefix = "psfDiff"
+            # Science forced flux as an extra feature, so the model can
+            # compare direct and difference photometry
+            extra_source_cols = ["psfFlux"]
+            extra_flag_cols = ["psfFlux_flag"]
         case _:
             raise NotImplementedError(f"img '{img}' is not supported")
 
@@ -251,7 +257,7 @@ def _open_catalog(
         "pixelFlags_saturated",
         "pixelFlags_cr",
         "pixelFlags_bad",
-    ]
+    ] + extra_flag_cols
     visit_cols = ["visit", "detector"] if read_visit_cols else []
 
     catalog = lsdb.open_catalog(
@@ -263,6 +269,7 @@ def _open_catalog(
             f"{source_col}.{flux_err_col}",
             f"{source_col}.{flux_flag_col}",
         ]
+        + [f"{source_col}.{col}" for col in extra_source_cols]
         + [f"{source_col}.{flag_col}" for flag_col in other_flag_cols]
         + obj_mag_cols
         + obj_extendedness_cols

--- a/src/uncle_val/learning/models/base.py
+++ b/src/uncle_val/learning/models/base.py
@@ -13,6 +13,8 @@ class UncleScaler:
     available_normalizers = {
         "x": "norm_flux",
         "flux": "norm_flux",
+        # Science forced flux, present as a feature for img="diff" catalogs
+        "psfFlux": "norm_flux",
         "err": "norm_err",
         "expTime": "norm_exp_time",
         "skyBg": "norm_sky_bg",

--- a/src/uncle_val/pipelines/plotting.py
+++ b/src/uncle_val/pipelines/plotting.py
@@ -201,6 +201,10 @@ def _get_hists(
     *,
     hash_range: tuple[float, float] | None = None,
     bands: Sequence[str],
+    obj: str,
+    img: str,
+    phot: str,
+    mode: str,
     min_n_src: int,
     non_extended_only: bool,
     n_workers: int,
@@ -216,10 +220,10 @@ def _get_hists(
     catalog = rubin_dp_catalog_multi_band(
         rubin_dp_root,
         bands=bands,
-        obj="science",
-        img="cal",
-        phot="PSF",
-        mode="forced",
+        obj=obj,
+        img=img,
+        phot=phot,
+        mode=mode,
     )
     if subsample_partitions is not None:
         n_partitions = max(1, int(round(catalog.npartitions * subsample_partitions)))
@@ -423,7 +427,6 @@ def make_plots(
     if split not in _split_map:
         raise ValueError(f"split must be one of 'train', 'val', 'test', 'all', or None; got {split!r}")
     hash_range = _split_map[split]
-    rubin_dp_root = survey_config.catalog_root
     if min_n_src is None:
         min_n_src = survey_config.n_src
 
@@ -450,9 +453,13 @@ def make_plots(
     add_mag_err_centers = 0.5 * (add_mag_err_bins[1:] + add_mag_err_bins[:-1])
 
     hists = _get_hists(
-        rubin_dp_root,
+        survey_config.catalog_root,
         hash_range=hash_range,
         bands=bands,
+        obj=survey_config.obj,
+        img=survey_config.img,
+        phot=survey_config.phot,
+        mode=survey_config.mode,
         min_n_src=min_n_src,
         non_extended_only=non_extended_only,
         n_workers=compute_config.n_workers,

--- a/src/uncle_val/pipelines/rubin_dp_constant_magerr.py
+++ b/src/uncle_val/pipelines/rubin_dp_constant_magerr.py
@@ -47,10 +47,10 @@ def run_rubin_dp_constant_magerr(
     catalog = rubin_dp_catalog_single_band(
         root=survey_config.catalog_root,
         band=band,
-        obj="science",
-        img="cal",
-        phot="PSF",
-        mode="forced",
+        obj=survey_config.obj,
+        img=survey_config.img,
+        phot=survey_config.phot,
+        mode=survey_config.mode,
     )
 
     if non_extended_only:

--- a/src/uncle_val/pipelines/rubin_dp_feature_importance.py
+++ b/src/uncle_val/pipelines/rubin_dp_feature_importance.py
@@ -89,10 +89,10 @@ def run_rubin_dp_feature_importance(
     catalog = rubin_dp_catalog_multi_band(
         root=survey_config.catalog_root,
         bands=bands,
-        obj="science",
-        img="cal",
-        phot="PSF",
-        mode="forced",
+        obj=survey_config.obj,
+        img=survey_config.img,
+        phot=survey_config.phot,
+        mode=survey_config.mode,
         pre_filter_partition=pre_filter_partition,
     ).map_partitions(lambda df: df.drop(columns=["band", "object_mag", "coord_ra", "coord_dec"]))
 

--- a/src/uncle_val/pipelines/rubin_dp_linear_flux_err.py
+++ b/src/uncle_val/pipelines/rubin_dp_linear_flux_err.py
@@ -47,10 +47,10 @@ def run_rubin_dp_linear_flux_err(
     catalog = rubin_dp_catalog_single_band(
         root=survey_config.catalog_root,
         band=band,
-        obj="science",
-        img="cal",
-        phot="PSF",
-        mode="forced",
+        obj=survey_config.obj,
+        img=survey_config.img,
+        phot=survey_config.phot,
+        mode=survey_config.mode,
     )
 
     if non_extended_only:

--- a/src/uncle_val/pipelines/splits.py
+++ b/src/uncle_val/pipelines/splits.py
@@ -4,6 +4,7 @@ import dataclasses
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -27,6 +28,15 @@ class SurveyConfig:
         Number of observations to subsample per light curve.
     bands : tuple of str, optional
         Survey filter bands. Defaults to all six LSST bands.
+    obj : str, optional
+        Type of object catalog, "science" or "dia". Defaults to "science".
+    img : str, optional
+        Type of image used for photometry, "cal" (calibrated) or
+        "diff" (subtracted). Defaults to "cal".
+    phot : str, optional
+        Type of photometry, "PSF". Defaults to "PSF".
+    mode : str, optional
+        Type of source coordinate mode, "forced". Defaults to "forced".
 
     Examples
     --------
@@ -44,6 +54,10 @@ class SurveyConfig:
     test_start: float
     n_src: int
     bands: tuple[str, ...] = ("u", "g", "r", "i", "z", "y")
+    obj: Literal["science", "dia"] = "science"
+    img: Literal["cal", "diff"] = "cal"
+    phot: Literal["PSF"] = "PSF"
+    mode: Literal["forced"] = "forced"
 
     def __post_init__(self):
         object.__setattr__(self, "catalog_root", Path(self.catalog_root))
@@ -54,6 +68,15 @@ class SurveyConfig:
             )
         if self.n_src < 1:
             raise ValueError(f"n_src must be >= 1, got {self.n_src}")
+        for field, allowed in [
+            ("obj", ("science", "dia")),
+            ("img", ("cal", "diff")),
+            ("phot", ("PSF",)),
+            ("mode", ("forced",)),
+        ]:
+            value = getattr(self, field)
+            if value not in allowed:
+                raise ValueError(f"{field} must be one of {allowed}, got {value!r}")
 
     def to_json(self, path: str | Path) -> None:
         """Serialize to a JSON file.
@@ -105,6 +128,10 @@ def dp1_config(
     val_start: float = 0.6,
     test_start: float = 0.85,
     bands: tuple[str, ...] = ("u", "g", "r", "i", "z", "y"),
+    obj: Literal["science", "dia"] = "science",
+    img: Literal["cal", "diff"] = "cal",
+    phot: Literal["PSF"] = "PSF",
+    mode: Literal["forced"] = "forced",
 ) -> SurveyConfig:
     """SurveyConfig for Rubin Data Preview 1.
 
@@ -120,6 +147,15 @@ def dp1_config(
         Val/test boundary. Defaults to 0.85.
     bands : tuple of str, optional
         Survey filter bands. Defaults to all six LSST bands.
+    obj : str, optional
+        Type of object catalog, "science" or "dia". Defaults to "science".
+    img : str, optional
+        Type of image used for photometry, "cal" (calibrated) or
+        "diff" (subtracted). Defaults to "cal".
+    phot : str, optional
+        Type of photometry, "PSF". Defaults to "PSF".
+    mode : str, optional
+        Type of source coordinate mode, "forced". Defaults to "forced".
 
     Returns
     -------
@@ -131,6 +167,10 @@ def dp1_config(
         val_start=val_start,
         test_start=test_start,
         bands=bands,
+        obj=obj,
+        img=img,
+        phot=phot,
+        mode=mode,
     )
 
 
@@ -141,6 +181,10 @@ def dp2_config(
     val_start: float = 0.84,
     test_start: float = 0.85,
     bands: tuple[str, ...] = ("u", "g", "r", "i", "z", "y"),
+    obj: Literal["science", "dia"] = "science",
+    img: Literal["cal", "diff"] = "cal",
+    phot: Literal["PSF"] = "PSF",
+    mode: Literal["forced"] = "forced",
 ) -> SurveyConfig:
     """SurveyConfig for Rubin Data Preview 2.
 
@@ -156,6 +200,15 @@ def dp2_config(
         Val/test boundary. Defaults to 0.85.
     bands : tuple of str, optional
         Survey filter bands. Defaults to all six LSST bands.
+    obj : str, optional
+        Type of object catalog, "science" or "dia". Defaults to "science".
+    img : str, optional
+        Type of image used for photometry, "cal" (calibrated) or
+        "diff" (subtracted). Defaults to "cal".
+    phot : str, optional
+        Type of photometry, "PSF". Defaults to "PSF".
+    mode : str, optional
+        Type of source coordinate mode, "forced". Defaults to "forced".
 
     Returns
     -------
@@ -167,4 +220,8 @@ def dp2_config(
         val_start=val_start,
         test_start=test_start,
         bands=bands,
+        obj=obj,
+        img=img,
+        phot=phot,
+        mode=mode,
     )

--- a/src/uncle_val/pipelines/train_on_rubin_dp.py
+++ b/src/uncle_val/pipelines/train_on_rubin_dp.py
@@ -60,10 +60,10 @@ def train_on_rubin_dp(
     catalog = rubin_dp_catalog_multi_band(
         root=survey_config.catalog_root,
         bands=bands,
-        obj="science",
-        img="cal",
-        phot="PSF",
-        mode="forced",
+        obj=survey_config.obj,
+        img=survey_config.img,
+        phot=survey_config.phot,
+        mode=survey_config.mode,
         pre_filter_partition=pre_filter_partition,
     ).map_partitions(lambda df: df.drop(columns=["band", "object_mag", "coord_ra", "coord_dec"]))
 
@@ -78,6 +78,10 @@ def train_on_rubin_dp(
         "lc.detector_cos_phi",
         "lc.detector_sin_phi",
     ] + [f"is_{band}_band" for band in bands]
+    if survey_config.img == "diff":
+        # Science forced flux, so the model sees how direct and difference
+        # photometry differ
+        columns.append("lc.psfFlux")
     columns_no_prefix = [col.removeprefix("lc.") for col in columns]
 
     if isinstance(model, str | Path):

--- a/tests/uncle_val/datasets/test_rubin_dp.py
+++ b/tests/uncle_val/datasets/test_rubin_dp.py
@@ -3,8 +3,8 @@ import pytest
 from uncle_val.datasets.rubin_dp import rubin_dp_catalog_multi_band
 
 
-@pytest.mark.parametrize("img, n_obj", [("cal", 106), ("diff", 115)])
-def test_rubin_dp_catalog_multi_band(rubin_dp_root, img, n_obj):
+@pytest.mark.parametrize("img, n_obj, n_src", [("cal", 106, 631), ("diff", 115, 973)])
+def test_rubin_dp_catalog_multi_band(rubin_dp_root, img, n_obj, n_src):
     """Test rubin_dp_catalog_multi_band()"""
     catalog = rubin_dp_catalog_multi_band(
         rubin_dp_root,
@@ -30,6 +30,7 @@ def test_rubin_dp_catalog_multi_band(rubin_dp_root, img, n_obj):
         "is_y_band",
         "lc",
     ]
+    extra_source_cols = ["psfFlux"] if img == "diff" else []
     assert df["lc"].dtype.field_names == [
         "expTime",
         "seeing",
@@ -37,6 +38,11 @@ def test_rubin_dp_catalog_multi_band(rubin_dp_root, img, n_obj):
         "detector_rho",
         "detector_cos_phi",
         "detector_sin_phi",
+        *extra_source_cols,
         "x",
         "err",
     ]
+    flat_lc = df["lc"].nest.to_flat()
+    assert len(flat_lc) == n_src
+    if img == "diff":
+        assert not flat_lc["psfFlux"].isna().any()

--- a/tests/uncle_val/learning/test_models.py
+++ b/tests/uncle_val/learning/test_models.py
@@ -135,6 +135,15 @@ def test_model(model):
     _ = model(torch.randn(model.d_input))
 
 
+def test_psf_flux_normalizer():
+    """psfFlux input (science forced flux for img="diff") is normalized as a flux"""
+    model = LinearModel(input_names=["x", "err", "psfFlux"], outputs_s=False)
+    assert set(model.normalizers) == {0, 1, 2}
+    inputs = torch.tensor([[1000.0, 10.0, 1000.0]])
+    normed = model.norm_inputs(inputs)
+    assert_allclose(normed[0, 2], normed[0, 0])
+
+
 @pytest.mark.parametrize(
     "loss_prod",
     [

--- a/tests/uncle_val/pipelines/test_splits.py
+++ b/tests/uncle_val/pipelines/test_splits.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from uncle_val.pipelines.splits import SurveyConfig, dp1_config
 
 
@@ -12,12 +14,28 @@ def test_survey_config_roundtrip(tmp_path):
         test_start=0.85,
         n_src=10,
         bands=("g", "r", "i"),
+        obj="science",
+        img="diff",
+        phot="PSF",
+        mode="forced",
     )
     path = tmp_path / "survey.json"
     cfg.to_json(path)
     assert path.exists()
     loaded = SurveyConfig.from_json(path)
     assert loaded == cfg
+    assert loaded.img == "diff"
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [("obj", "galaxy"), ("img", "coadd"), ("phot", "aperture"), ("mode", "free")],
+)
+def test_survey_config_invalid_catalog_choice(field, value):
+    """Invalid obj/img/phot/mode values must be rejected."""
+    kwargs = {"catalog_root": "/data/dp1", "val_start": 0.6, "test_start": 0.85, "n_src": 10, field: value}
+    with pytest.raises(ValueError, match=field):
+        SurveyConfig(**kwargs)
 
 
 def test_survey_config_roundtrip_path_object(tmp_path):


### PR DESCRIPTION
## Summary

For difference-image photometry (`img="diff"`), the model previously saw only the DIA flux (`psfDiffFlux` → `x`) and its error. This PR adds the science-image forced PSF flux (`psfFlux`, without its error) as a feature, so the model can learn from the discrepancy between DIA and science fluxes, and pre-filters observations on `psfFlux_flag` in addition to the existing flag filters.

## Changes

- **`datasets/rubin_dp.py`**: for `img="diff"`, `_open_catalog()` also reads `psfFlux` (kept under its original name as nested field `lc.psfFlux`) and `psfFlux_flag`; the flag is folded into `other_flag_cols`, so `_filter_bad_obs()` filters on it and drops it in both single-band and multi-band paths.
- **`pipelines/splits.py`**: `SurveyConfig` gains `obj`/`img`/`phot`/`mode` fields (validated, defaults match the previously hardcoded values, exposed through `dp1_config()`/`dp2_config()`). Since `training_loop()` serializes the config, these choices are now recorded per run.
- **Pipelines** (`train_on_rubin_dp`, `rubin_dp_constant_magerr`, `rubin_dp_linear_flux_err`, `rubin_dp_feature_importance`, `plotting`): pass the four values from `survey_config` instead of hardcoded `obj="science", img="cal", phot="PSF", mode="forced"`. The dataset-layer functions keep explicit parameters. `train_on_rubin_dp()` appends `lc.psfFlux` to the model columns when `img="diff"`.
- **`learning/models/base.py`**: `UncleScaler` normalizes `psfFlux` with the arcsinh flux normalizer.

## Testing

- `test_rubin_dp_catalog_multi_band` now checks the `psfFlux` nested field, flat source-row counts, and that `psfFlux` has no NaNs for `img="diff"`.
- New test that a model with `psfFlux` in `input_names` picks up the flux normalizer.
- `SurveyConfig` tests extended with round-trip of the new fields and rejection of invalid values.
- End-to-end smoke verified: diff catalog on test fixture → `LSDBIterableDataset` → `MLPModel` forward pass with 16 features, finite outputs.

Note: on the test fixture, `psfFlux_flag` never fires without another flag also firing, so the new filter is exercised but does not change fixture counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)