### PR TITLE
Derive training columns from the model's input_names

### DIFF
--- a/src/uncle_val/learning/models/base.py
+++ b/src/uncle_val/learning/models/base.py
@@ -110,6 +110,12 @@ class BaseUncleModel(torch.nn.Module):
 
     def norm_inputs(self, inputs: torch.Tensor) -> torch.Tensor:
         """Normalizes batch"""
+        # The column loop below selects the first d_input columns, so a wider
+        # batch would otherwise be silently truncated.
+        if inputs.shape[-1] != self.d_input:
+            raise ValueError(
+                f"Expected {self.d_input} input features {self.input_names}, got {inputs.shape[-1]}"
+            )
         # In-place per-column assignment traces to a fixed-batch-size scatter under
         # torch.export, so rebuild the tensor via cat instead.
         columns = [

--- a/src/uncle_val/pipelines/train_on_rubin_dp.py
+++ b/src/uncle_val/pipelines/train_on_rubin_dp.py
@@ -22,6 +22,11 @@ def rubin_dp_catalog_and_columns(
 ) -> tuple[lsdb.Catalog, list[str]]:
     """Build the training catalog and the catalog columns to feed the model.
 
+    The model's ``input_names`` define which catalog columns are used and in
+    which order; e.g. include "psfFlux" (science forced flux) for
+    ``img="diff"`` catalogs so the model sees how direct and difference
+    photometry differ.
+
     Parameters
     ----------
     model : BaseUncleModel
@@ -40,8 +45,13 @@ def rubin_dp_catalog_and_columns(
     lsdb.Catalog
         Catalog to train on.
     list[str]
-        Catalog columns to use as model inputs; nested light-curve fields are
-        prefixed with ``lc.``.
+        Catalog columns matching ``model.input_names`` one-to-one; nested
+        light-curve fields are prefixed with ``lc.``.
+
+    Raises
+    ------
+    ValueError
+        If some model input is not available in the catalog.
     """
     bands = survey_config.bands if bands is None else tuple(bands)
     catalog = rubin_dp_catalog_multi_band(
@@ -54,21 +64,20 @@ def rubin_dp_catalog_and_columns(
         pre_filter_partition=pre_filter_partition,
     ).map_partitions(lambda df: df.drop(columns=["band", "object_mag", "coord_ra", "coord_dec"]))
 
-    columns = [
-        "lc.x",
-        "lc.err",
-        "extendedness",
-        "lc.skyBg",
-        "lc.seeing",
-        "lc.expTime",
-        "lc.detector_rho",
-        "lc.detector_cos_phi",
-        "lc.detector_sin_phi",
-    ] + [f"is_{band}_band" for band in bands]
-    if survey_config.img == "diff":
-        # Science forced flux, so the model sees how direct and difference
-        # photometry differ
-        columns.append("lc.psfFlux")
+    lc_fields = list(catalog.dtypes["lc"].column_dtypes)
+    flat_columns = [col for col in catalog.columns if col != "lc"]
+
+    columns = []
+    for name in model.input_names:
+        if name in lc_fields:
+            columns.append(f"lc.{name}")
+        elif name in flat_columns:
+            columns.append(name)
+        else:
+            raise ValueError(
+                f"Model input {name!r} is not available in the catalog: "
+                f"nested 'lc' fields are {lc_fields}, other columns are {flat_columns}"
+            )
 
     return catalog, columns
 
@@ -90,7 +99,9 @@ def train_on_rubin_dp(
     ----------
     model : BaseUncleModel or str or Path
         Model instance to train, or a path to a saved model to load and
-        continue training from.
+        continue training from. The model's ``input_names`` define which
+        catalog columns are used as inputs and in which order, see
+        :func:`rubin_dp_catalog_and_columns`.
     output_dir : str or Path
         Run directory to save all the outputs to, see
         :func:`~uncle_val.pipelines.training_loop.training_loop` for details.
@@ -115,7 +126,8 @@ def train_on_rubin_dp(
     Path
         Path to the output model.
     list[str]
-        List of columns used as model inputs.
+        Catalog columns used as model inputs, matching ``model.input_names``
+        one-to-one; nested light-curve fields are prefixed with ``lc.``.
     """
     if isinstance(model, str | Path):
         model = torch.load(model, weights_only=False, map_location=training_config.compute_config.device)

--- a/src/uncle_val/pipelines/train_on_rubin_dp.py
+++ b/src/uncle_val/pipelines/train_on_rubin_dp.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
+import lsdb
 import torch
 from nested_pandas import NestedFrame
 
@@ -10,6 +11,66 @@ from uncle_val.learning.models import BaseUncleModel
 from uncle_val.pipelines.splits import SurveyConfig
 from uncle_val.pipelines.training_config import TrainingConfig
 from uncle_val.pipelines.training_loop import training_loop
+
+
+def rubin_dp_catalog_and_columns(
+    *,
+    model: BaseUncleModel,
+    survey_config: SurveyConfig,
+    bands: Sequence[str] | None = None,
+    pre_filter_partition: Callable[[NestedFrame], NestedFrame] | None = None,
+) -> tuple[lsdb.Catalog, list[str]]:
+    """Build the training catalog and the catalog columns to feed the model.
+
+    Parameters
+    ----------
+    model : BaseUncleModel
+        Model to be trained on the returned catalog columns.
+    survey_config : SurveyConfig
+        Survey configuration including catalog root, split boundaries, and n_src.
+    bands : sequence of str or None
+        Bands to include, subset of ``ugrizy``. Defaults to ``survey_config.bands``.
+    pre_filter_partition : callable or None
+        Optional function applied to each catalog partition before any other
+        processing. Receives a ``NestedFrame`` and returns a filtered
+        ``NestedFrame``.
+
+    Returns
+    -------
+    lsdb.Catalog
+        Catalog to train on.
+    list[str]
+        Catalog columns to use as model inputs; nested light-curve fields are
+        prefixed with ``lc.``.
+    """
+    bands = survey_config.bands if bands is None else tuple(bands)
+    catalog = rubin_dp_catalog_multi_band(
+        root=survey_config.catalog_root,
+        bands=bands,
+        obj=survey_config.obj,
+        img=survey_config.img,
+        phot=survey_config.phot,
+        mode=survey_config.mode,
+        pre_filter_partition=pre_filter_partition,
+    ).map_partitions(lambda df: df.drop(columns=["band", "object_mag", "coord_ra", "coord_dec"]))
+
+    columns = [
+        "lc.x",
+        "lc.err",
+        "extendedness",
+        "lc.skyBg",
+        "lc.seeing",
+        "lc.expTime",
+        "lc.detector_rho",
+        "lc.detector_cos_phi",
+        "lc.detector_sin_phi",
+    ] + [f"is_{band}_band" for band in bands]
+    if survey_config.img == "diff":
+        # Science forced flux, so the model sees how direct and difference
+        # photometry differ
+        columns.append("lc.psfFlux")
+
+    return catalog, columns
 
 
 def train_on_rubin_dp(
@@ -56,36 +117,16 @@ def train_on_rubin_dp(
     list[str]
         List of columns used as model inputs.
     """
-    bands = survey_config.bands if bands is None else tuple(bands)
-    catalog = rubin_dp_catalog_multi_band(
-        root=survey_config.catalog_root,
-        bands=bands,
-        obj=survey_config.obj,
-        img=survey_config.img,
-        phot=survey_config.phot,
-        mode=survey_config.mode,
-        pre_filter_partition=pre_filter_partition,
-    ).map_partitions(lambda df: df.drop(columns=["band", "object_mag", "coord_ra", "coord_dec"]))
-
-    columns = [
-        "lc.x",
-        "lc.err",
-        "extendedness",
-        "lc.skyBg",
-        "lc.seeing",
-        "lc.expTime",
-        "lc.detector_rho",
-        "lc.detector_cos_phi",
-        "lc.detector_sin_phi",
-    ] + [f"is_{band}_band" for band in bands]
-    if survey_config.img == "diff":
-        # Science forced flux, so the model sees how direct and difference
-        # photometry differ
-        columns.append("lc.psfFlux")
-    columns_no_prefix = [col.removeprefix("lc.") for col in columns]
-
     if isinstance(model, str | Path):
         model = torch.load(model, weights_only=False, map_location=training_config.compute_config.device)
+
+    catalog, columns = rubin_dp_catalog_and_columns(
+        model=model,
+        survey_config=survey_config,
+        bands=bands,
+        pre_filter_partition=pre_filter_partition,
+    )
+    columns_no_prefix = [col.removeprefix("lc.") for col in columns]
 
     if val_losses is None:
         val_losses = {}

--- a/tests/uncle_val/learning/test_models.py
+++ b/tests/uncle_val/learning/test_models.py
@@ -135,6 +135,19 @@ def test_model(model):
     _ = model(torch.randn(model.d_input))
 
 
+def test_model_rejects_wrong_feature_count():
+    """A batch whose width doesn't match input_names must raise, not be silently truncated"""
+    model = MLPModel(input_names=["x", "err", "skyBg"], outputs_s=False, d_middle=(4,))
+    with pytest.raises(ValueError, match="3 input features"):
+        model(torch.rand(2, 5, 4) + 1.0)
+    with pytest.raises(ValueError, match="3 input features"):
+        model(torch.rand(2, 5, 2) + 1.0)
+
+    magerr_model = ConstantMagErrModel(input_names=["x", "err"])
+    with pytest.raises(ValueError, match="2 input features"):
+        magerr_model(torch.rand(2, 5, 3) + 1.0)
+
+
 def test_psf_flux_normalizer():
     """psfFlux input (science forced flux for img="diff") is normalized as a flux"""
     model = LinearModel(input_names=["x", "err", "psfFlux"], outputs_s=False)

--- a/tests/uncle_val/pipelines/test_train_on_rubin_dp.py
+++ b/tests/uncle_val/pipelines/test_train_on_rubin_dp.py
@@ -1,0 +1,47 @@
+from uncle_val.learning.lsdb_dataset import LSDBIterableDataset
+from uncle_val.learning.models import MLPModel
+from uncle_val.pipelines.splits import dp1_config
+from uncle_val.pipelines.train_on_rubin_dp import rubin_dp_catalog_and_columns
+
+BANDS = ("u", "g", "r", "i", "z", "y")
+
+BASE_INPUT_NAMES = [
+    "x",
+    "err",
+    "extendedness",
+    "skyBg",
+    "seeing",
+    "expTime",
+    "detector_rho",
+    "detector_cos_phi",
+    "detector_sin_phi",
+] + [f"is_{band}_band" for band in BANDS]
+
+
+def test_rubin_dp_catalog_and_columns_feed_model(rubin_dp_root):
+    """Columns produced for img="diff" must feed a model not using psfFlux.
+
+    Regression test: the pipeline used to append "lc.psfFlux" for img="diff"
+    regardless of the model's inputs, feeding 16 features to a model built
+    for 15 and crashing in the first linear layer (or silently dropping the
+    last feature, depending on the model's input normalization details).
+    """
+    model = MLPModel(input_names=BASE_INPUT_NAMES, outputs_s=False, d_middle=(8,))
+    catalog, columns = rubin_dp_catalog_and_columns(
+        model=model,
+        survey_config=dp1_config(rubin_dp_root, n_src=5, img="diff"),
+    )
+    assert [col.removeprefix("lc.") for col in columns] == model.input_names
+
+    dataset = LSDBIterableDataset(
+        catalog,
+        columns=[col.removeprefix("lc.") for col in columns],
+        client=None,
+        batch_lc=1,
+        n_src=5,
+        partitions_per_chunk=1,
+        seed=0,
+    )
+    batch = next(iter(dataset))
+    output = model(batch)
+    assert output.shape == (1, 5, 1)

--- a/tests/uncle_val/pipelines/test_train_on_rubin_dp.py
+++ b/tests/uncle_val/pipelines/test_train_on_rubin_dp.py
@@ -1,3 +1,5 @@
+import pytest
+
 from uncle_val.learning.lsdb_dataset import LSDBIterableDataset
 from uncle_val.learning.models import MLPModel
 from uncle_val.pipelines.splits import dp1_config
@@ -45,3 +47,24 @@ def test_rubin_dp_catalog_and_columns_feed_model(rubin_dp_root):
     batch = next(iter(dataset))
     output = model(batch)
     assert output.shape == (1, 5, 1)
+
+
+def test_rubin_dp_catalog_and_columns_psf_flux(rubin_dp_root):
+    """A model asking for psfFlux gets the nested lc.psfFlux column for img="diff"."""
+    model = MLPModel(input_names=BASE_INPUT_NAMES + ["psfFlux"], outputs_s=False, d_middle=(8,))
+    _catalog, columns = rubin_dp_catalog_and_columns(
+        model=model,
+        survey_config=dp1_config(rubin_dp_root, n_src=5, img="diff"),
+    )
+    assert [col.removeprefix("lc.") for col in columns] == model.input_names
+    assert columns[-1] == "lc.psfFlux"
+
+
+def test_rubin_dp_catalog_and_columns_unavailable_input_raises(rubin_dp_root):
+    """psfFlux does not exist in img="cal" catalogs, so it must raise."""
+    model = MLPModel(input_names=BASE_INPUT_NAMES + ["psfFlux"], outputs_s=False, d_middle=(8,))
+    with pytest.raises(ValueError, match="psfFlux"):
+        rubin_dp_catalog_and_columns(
+            model=model,
+            survey_config=dp1_config(rubin_dp_root, n_src=5, img="cal"),
+        )


### PR DESCRIPTION
## Problem

`train_on_rubin_dp()` built a hardcoded column list independent of the model's `input_names`. Since #91, it appended `lc.psfFlux` for `img="diff"`, feeding 16 features to a model built for 15:

```
RuntimeError: mat1 and mat2 shapes cannot be multiplied (5120x16 and 15x300)
```

With the `norm_inputs` rewrite from #92 the same mismatch would instead *silently truncate* the batch to the first 15 columns. More generally, a same-length column list in a different order would silently train on misaligned features.

## Fix

The model is the single source of truth: `rubin_dp_catalog_and_columns()` maps `model.input_names` to catalog columns (nested light-curve fields get the `lc.` prefix), preserving the model's order, and raises a `ValueError` naming the missing input if it is not available in the catalog (e.g. `psfFlux` requested on an `img="cal"` catalog).

Note the behavior change: `psfFlux` is no longer force-added for `img="diff"` — opt in by including `"psfFlux"` in the model's `input_names` (`UncleScaler` already normalizes it).

## Commits

1. Extract `rubin_dp_catalog_and_columns()` helper — no behavior change.
2. Add the failing regression test: real `img="diff"` catalog from `tests/data/dp1` → `LSDBIterableDataset` (`client=None`, no Dask) → one batch → model forward.
3. The fix, plus tests for the `psfFlux` opt-in and the unavailable-input error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)