### PR TITLE
Add script counting trainable light curves per band and split

### DIFF
--- a/scripts/count_trainable_lcs.py
+++ b/scripts/count_trainable_lcs.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from uncle_val.datasets.rubin_dp import rubin_dp_catalog_multi_band
+from uncle_val.learning.lsdb_dataset import filter_trainable_lcs
+from uncle_val.pipelines.splits import SurveyConfig, dp1_config, dp2_config
+
+LC_COL = "lc"
+ID_COL = "id"
+SPLIT_NAMES = ("train", "val", "test")
+
+
+def parse_args(argv=None):
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Count trainable light curves in a Rubin DP HATS catalog, "
+        "using the same selection as the training pipeline: "
+        "light curves with at least n_src observations, split into "
+        "train/val/test by hashing the object ID. "
+        "Use it to convert the number of light curves seen during training "
+        "into the number of epochs (n_lcs_seen / train count)."
+    )
+    config_group = parser.add_mutually_exclusive_group(required=True)
+    config_group.add_argument(
+        "--survey-config",
+        type=Path,
+        help="Path to a survey_config.json saved with a training run.",
+    )
+    config_group.add_argument(
+        "--preset",
+        choices=["dp1", "dp2"],
+        help="Use dp1_config/dp2_config defaults instead of a JSON file; "
+        "requires --catalog-root and --n-src.",
+    )
+    parser.add_argument(
+        "--catalog-root",
+        type=Path,
+        default=None,
+        help="Root directory of the HATS catalogs. Required with --preset; "
+        "with --survey-config it overrides the (possibly relative) "
+        "catalog_root stored in the JSON.",
+    )
+    parser.add_argument(
+        "--n-src",
+        type=int,
+        default=None,
+        help="Observations per light curve. Required with --preset; "
+        "with --survey-config it overrides the stored value.",
+    )
+    parser.add_argument(
+        "--n-workers",
+        type=int,
+        default=None,
+        help="If given, start a dask.distributed client with that many workers.",
+    )
+    return parser.parse_args(argv)
+
+
+def make_survey_config(args) -> SurveyConfig:
+    """Build the SurveyConfig from the command-line arguments."""
+    if args.survey_config is not None:
+        config = SurveyConfig.from_json(args.survey_config)
+        overrides = {}
+        if args.catalog_root is not None:
+            overrides["catalog_root"] = args.catalog_root
+        if args.n_src is not None:
+            overrides["n_src"] = args.n_src
+        if overrides:
+            import dataclasses
+
+            config = dataclasses.replace(config, **overrides)
+        return config
+
+    if args.catalog_root is None or args.n_src is None:
+        raise ValueError("--preset requires both --catalog-root and --n-src")
+    preset = {"dp1": dp1_config, "dp2": dp2_config}[args.preset]
+    return preset(args.catalog_root, n_src=args.n_src)
+
+
+def _count_partition(nf, *, n_src: int, splits: dict[str, tuple[float, float]]) -> pd.DataFrame:
+    """Per-band, per-split counts of trainable light curves in one partition."""
+    parts = []
+    for split_name, hash_range in splits.items():
+        filtered, length_col = filter_trainable_lcs(
+            nf, n_src=n_src, hash_range=hash_range, lc_col=LC_COL, id_col=ID_COL
+        )
+        counts = filtered.groupby("band", as_index=False, observed=True).agg(
+            n_lc=("band", "size"),
+            n_obs=(length_col, "sum"),
+        )
+        counts["split"] = split_name
+        parts.append(counts)
+    return pd.concat(parts, ignore_index=True)
+
+
+_COUNT_META = pd.DataFrame(
+    {
+        "band": pd.Series(dtype=str),
+        "n_lc": pd.Series(dtype=np.int64),
+        "n_obs": pd.Series(dtype=np.int64),
+        "split": pd.Series(dtype=str),
+    }
+)
+
+
+def count_trainable_lcs(survey_config: SurveyConfig) -> pd.DataFrame:
+    """Count trainable light curves per band and per split.
+
+    A light curve is trainable if it survives the catalog quality and
+    variability filters and has at least ``survey_config.n_src`` observations.
+
+    Parameters
+    ----------
+    survey_config : SurveyConfig
+        Survey configuration including catalog root, split boundaries, and n_src.
+
+    Returns
+    -------
+    pd.DataFrame
+        Long-format summary with columns "band" (including "all"), "split",
+        "n_lc", and "n_obs".
+    """
+    catalog = rubin_dp_catalog_multi_band(
+        root=survey_config.catalog_root,
+        bands=survey_config.bands,
+        obj=survey_config.obj,
+        img=survey_config.img,
+        phot=survey_config.phot,
+        mode=survey_config.mode,
+    )
+    splits = {
+        "train": survey_config.train_split,
+        "val": survey_config.val_split,
+        "test": survey_config.test_split,
+    }
+    partition_counts = catalog.map_partitions(
+        _count_partition,
+        n_src=survey_config.n_src,
+        splits=splits,
+        meta=_COUNT_META,
+    ).compute()
+
+    per_band = partition_counts.groupby(["band", "split"], as_index=False, observed=True).sum()
+    per_split = per_band.groupby("split", as_index=False, observed=True).sum().assign(band="all")
+    summary = pd.concat([per_band, per_split], ignore_index=True)
+    summary["split"] = pd.Categorical(summary["split"], categories=SPLIT_NAMES, ordered=True)
+    return summary.sort_values(["band", "split"], ignore_index=True)
+
+
+def main(argv=None):
+    """Count trainable light curves and print the summary."""
+    args = parse_args(argv)
+    survey_config = make_survey_config(args)
+
+    client = None
+    if args.n_workers is not None:
+        from distributed import Client
+
+        client = Client(n_workers=args.n_workers, threads_per_worker=1)
+        print(f"Dask dashboard: {client.dashboard_link}")
+
+    try:
+        table = count_trainable_lcs(survey_config)
+    finally:
+        if client is not None:
+            client.close()
+
+    print(f"Trainable light curves for {survey_config.catalog_root}, n_src >= {survey_config.n_src}:")
+    print(table.to_string(index=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/uncle_val/learning/lsdb_dataset.py
+++ b/src/uncle_val/learning/lsdb_dataset.py
@@ -42,6 +42,51 @@ def _process_lc(
     return result
 
 
+def filter_trainable_lcs(
+    nf: NestedFrame,
+    *,
+    n_src: int,
+    hash_range: tuple[float, float] | None,
+    lc_col: str,
+    id_col: str,
+) -> tuple[NestedFrame, str]:
+    """Select light curves the training pipeline would use.
+
+    Keeps light curves with at least `n_src` observations and, if
+    `hash_range` is given, whose hashed `id_col` values fall into it.
+
+    Parameters
+    ----------
+    nf : NestedFrame
+        Frame with nested light curves.
+    n_src : int
+        Minimum number of observations per light curve.
+    hash_range : (float, float) or None
+        Compute hashes ∈ [0; 1) on `id_col` values and keep only those in
+        the given [min; max) range. If `None`, no hash filtering is applied.
+    lc_col : str
+        Nested light-curve column name.
+    id_col : str
+        Identifier column name used for hashing.
+
+    Returns
+    -------
+    NestedFrame
+        The filtered frame, with an extra column of light-curve lengths.
+    str
+        The name of the added length column.
+    """
+    length_col = f"__length_{lc_col}_"
+    nf = nf.assign(**{length_col: nf[lc_col].nest.list_lengths})
+    nf = nf.query(f"{length_col} >= {n_src}")
+
+    if hash_range is not None:
+        hashes = uniform_hash(nf[id_col])
+        mask = (hashes >= hash_range[0]) & (hashes < hash_range[1])
+        nf = nf[mask]
+    return nf, length_col
+
+
 def _process_partition(
     nf: NestedFrame,
     pixel: HealpixPixel,
@@ -53,14 +98,9 @@ def _process_partition(
     hash_range: tuple[int, int] | None,
     seed: Variable,
 ) -> NestedFrame:
-    length_col = f"__length_{lc_col}_"
-    nf[length_col] = nf[lc_col].nest.list_lengths
-    nf = nf.query(f"{length_col} >= {n_src}")
-
-    if hash_range is not None:
-        hashes = uniform_hash(nf[id_col])
-        mask = (hashes >= hash_range[0]) & (hashes < hash_range[1])
-        nf = nf[mask]
+    nf, length_col = filter_trainable_lcs(
+        nf, n_src=n_src, hash_range=hash_range, lc_col=lc_col, id_col=id_col
+    )
     if id_col in nf.columns:
         nf = nf.drop(columns=[id_col])
 


### PR DESCRIPTION
## Summary

- New `scripts/count_trainable_lcs.py`: counts trainable light curves (and their observations) per band and per train/val/test split in a Rubin DP HATS catalog, using LSDB + Dask. Configured either from a training run's `survey_config.json` or from the `dp1`/`dp2` presets. The train-split count converts the `n_lcs` seen during training into the number of epochs.
- Refactor: extract the light-curve selection (length cut + hash-based split) from `_process_partition` into a reusable `filter_trainable_lcs()`, so the script counts with exactly the training-pipeline selection. The helper uses `assign()` instead of in-place column assignment to avoid mutating the catalog's dask meta.

## Test plan

- Ran on local DP1 (`--preset dp1 --catalog-root data/dp1 --n-src 10 --n-workers 8`, ~52 s): train/val/test = 843,670 / 352,237 / 212,195 light curves; the train fraction (59.9%) matches `val_start=0.6`.
- Pre-commit hooks (ruff, unit tests) pass.

To run on DP2:
```bash
python scripts/count_trainable_lcs.py \
  --survey-config models/2026-06-10_DP2_Object_ForcedSource/survey_config.json \
  --catalog-root <path-to-dp2> --n-workers 16
```