### PR TITLE
Don't discard count results when Dask shutdown hangs

### DIFF
--- a/scripts/count_trainable_lcs.py
+++ b/scripts/count_trainable_lcs.py
@@ -177,12 +177,17 @@ def main(argv=None):
 
     try:
         table = count_trainable_lcs(survey_config)
+        # Print before tearing down the cluster: on shared clusters
+        # client.close() can hang and raise TimeoutError, which would
+        # otherwise discard the already-computed result.
+        print(f"Trainable light curves for {survey_config.catalog_root}, n_src >= {survey_config.n_src}:")
+        print(table.to_string(index=False))
     finally:
         if client is not None:
-            client.close()
-
-    print(f"Trainable light curves for {survey_config.catalog_root}, n_src >= {survey_config.n_src}:")
-    print(table.to_string(index=False))
+            try:
+                client.close()
+            except Exception as exc:  # noqa: BLE001
+                print(f"Warning: ignoring error during Dask client shutdown: {exc!r}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On shared clusters, `client.close()` can hang and raise `TimeoutError` while the Dask nanny fails to kill workers in time. In `count_trainable_lcs.py`'s `main()`, the results table was printed *after* the `finally: client.close()` block, so a shutdown hang discarded an already-computed result (observed on a DP2 run).

Changes:
- Print the counts table inside the `try`, right after `count_trainable_lcs()` returns, before cluster teardown.
- Wrap `client.close()` in `try/except` so shutdown errors are logged as a warning instead of aborting the run.

No change to the counting logic.