### PR TITLE
Fix make_plots '_corrected' suffix and label logic

### DIFF
--- a/src/uncle_val/pipelines/plotting.py
+++ b/src/uncle_val/pipelines/plotting.py
@@ -284,7 +284,7 @@ def _plot_hist(
     if mag_bin is not None:
         title = f"{title}; for mag=[{mag_bin[0]}; {mag_bin[1]}]"
     ax.set_title(title)
-    label = "corrected data" if if_model is None else "data"
+    label = "corrected data" if if_model else "data"
     ax.bar(x=df["value_centers"], height=df["prob_dens"], width=z_width, label=label, color="blue", alpha=0.2)
     ax.plot(z_bins, norm(loc=mean, scale=std).pdf(z_bins), label="Normal PDF fit", color="blue", alpha=1.0)
     ax.plot(
@@ -437,7 +437,7 @@ def make_plots(
 
     if_model = model_path is not None
 
-    filename_suffix = "" if if_model is None else "_corrected"
+    filename_suffix = "_corrected" if if_model else ""
 
     bands = "ugrizy"
 


### PR DESCRIPTION
`make_plots()` sets `if_model = model_path is not None` (a bool), then tests `if_model is None`, which is always `False`. As a result:

- `filename_suffix` was always `"_corrected"`, so uncorrected (`model_path=None`) figures were written with the `_corrected` suffix and would overwrite the model-corrected figures generated into the same directory.
- The histogram legend label was always `"data"`, never `"corrected data"`.

Fix uses the bool directly:
- `filename_suffix = "_corrected" if if_model else ""`
- `label = "corrected data" if if_model else "data"`

No change to any computed values (histograms, fitted mean/σ, correction math); only output filenames and the legend label.