### PR TITLE
Support DiaObject catalogs

### DIFF
--- a/scripts/plot_kl.py
+++ b/scripts/plot_kl.py
@@ -26,6 +26,8 @@ def main():
     p.add_argument("--model-file", default="MLPModel.pt", help="Model file within --model-dir.")
     p.add_argument("--catalog-root", type=Path, required=True, help="Override catalog_root (absolute).")
     p.add_argument("--split", default="test", help="'train', 'val', 'test', 'all', or 'none'.")
+    p.add_argument("--obj", choices=["science", "dia"], default=None, help="Override object catalog type.")
+    p.add_argument("--img", choices=["cal", "diff"], default=None, help="Override image type.")
     p.add_argument("--n-workers", type=int, default=8)
     p.add_argument("--device", default="cpu")
     p.add_argument("--subsample-partitions", type=float, default=None)
@@ -33,9 +35,14 @@ def main():
     args = p.parse_args()
 
     split = None if args.split.lower() in ("none", "all") else args.split
+    overrides = {"catalog_root": str(args.catalog_root)}
+    if args.obj is not None:
+        overrides["obj"] = args.obj
+    if args.img is not None:
+        overrides["img"] = args.img
     survey_config = dataclasses.replace(
         SurveyConfig.from_json(args.model_dir / "survey_config.json"),
-        catalog_root=str(args.catalog_root),
+        **overrides,
     )
     model_path = args.model_dir / args.model_file
     model = torch.load(model_path, weights_only=False, map_location="cpu")

--- a/scripts/plot_reduced_chi2.py
+++ b/scripts/plot_reduced_chi2.py
@@ -25,6 +25,8 @@ def main():
     p.add_argument("--model-file", default="MLPModel.pt", help="Model file within --model-dir.")
     p.add_argument("--catalog-root", type=Path, required=True, help="Override catalog_root (absolute).")
     p.add_argument("--split", default="test", help="'train', 'val', 'test', 'all', or 'none'.")
+    p.add_argument("--obj", choices=["science", "dia"], default=None, help="Override object catalog type.")
+    p.add_argument("--img", choices=["cal", "diff"], default=None, help="Override image type.")
     p.add_argument("--n-workers", type=int, default=8)
     p.add_argument("--device", default="cpu")
     p.add_argument("--subsample-partitions", type=float, default=None)
@@ -32,9 +34,14 @@ def main():
     args = p.parse_args()
 
     split = None if args.split.lower() in ("none", "all") else args.split
+    overrides = {"catalog_root": str(args.catalog_root)}
+    if args.obj is not None:
+        overrides["obj"] = args.obj
+    if args.img is not None:
+        overrides["img"] = args.img
     survey_config = dataclasses.replace(
         SurveyConfig.from_json(args.model_dir / "survey_config.json"),
-        catalog_root=str(args.catalog_root),
+        **overrides,
     )
     model_path = args.model_dir / args.model_file
     model = torch.load(model_path, weights_only=False, map_location="cpu")

--- a/src/uncle_val/datasets/rubin_dp.py
+++ b/src/uncle_val/datasets/rubin_dp.py
@@ -9,6 +9,7 @@ import pyarrow.feather as feather
 from nested_pandas import NestedFrame
 from upath import UPath
 
+from uncle_val.utils.mag_flux import flux2mag
 from uncle_val.variability_detectors import get_combined_variability_detector
 
 LSDB_BANDS = "ugrizy"
@@ -97,6 +98,24 @@ def _split_light_curves_by_band(
     return pd.concat(single_band_dfs)
 
 
+def _normalize_dia_object_columns(df, *, bands):
+    """Give DiaObject partitions the object-level columns the science path expects.
+
+    The DiaObject catalog has no per-band ``psfMag`` or ``extendedness`` object
+    columns. We derive the object magnitude from the mean science (direct-image)
+    flux ``{band}_scienceFluxMean`` and, for now, set ``extendedness`` to zero,
+    i.e. treat DiaObjects as point sources.
+
+    TODO: cross-match with the science Object catalog to obtain a real per-object
+    ``extendedness`` (and magnitude) instead of assuming a point source.
+    """
+    for band in bands:
+        df[f"{band}_psfMag"] = flux2mag(np.asarray(df[f"{band}_scienceFluxMean"]))
+        df = df.drop(columns=[f"{band}_scienceFluxMean"])
+        df[f"{band}_extendedness"] = 0.0
+    return df
+
+
 def _filter_variable_lcs(df, *, nested_flux_col, nested_err_col, var_detector):
     if len(df) == 0:
         return df
@@ -173,6 +192,7 @@ def _process_partition_multi_band(
     var_detector,
     ccd_visits_path,
     ccd_visits_cols,
+    require_object_mag=True,
 ):
     df = _rename_columns(df, lc_col=lc_col, id_col=id_col, flux_col=flux_col, flux_err_col=flux_err_col)
 
@@ -182,7 +202,11 @@ def _process_partition_multi_band(
 
     # Filter bands and split light curves (rows) by band
     df = _split_light_curves_by_band(df, bands=bands, lc_col="lc")
-    df = df.dropna(subset=["lc", "object_mag", "extendedness"])
+    # For DiaObjects the object magnitude is derived from the mean science flux
+    # and may be undefined (non-positive flux); keeping those light curves does
+    # not affect the whitening, so we do not require it there.
+    required_cols = ["lc", "extendedness"] + (["object_mag"] if require_object_mag else [])
+    df = df.dropna(subset=required_cols)
 
     # Filter out variable light curves
     df = _filter_variable_lcs(df, nested_flux_col="lc.x", nested_err_col="lc.err", var_detector=var_detector)
@@ -218,12 +242,17 @@ def _open_catalog(
         case "science":
             catalog_name = "object_collection"
             id_col = "objectId"
+        case "dia":
+            catalog_name = "dia_object_collection"
+            id_col = "diaObjectId"
         case _:
-            raise NotImplementedError(f"obg '{obj}' not implemented")
+            raise NotImplementedError(f"obj '{obj}' not implemented")
 
     match mode, obj:
         case "forced", "science":
             source_col = "objectForcedSource"
+        case "forced", "dia":
+            source_col = "diaObjectForcedSource"
         case _:
             raise NotImplementedError(f"mode '{mode}' and obj '{obj}' are not supported")
 
@@ -248,9 +277,14 @@ def _open_catalog(
     flux_err_col = f"{flux_col}Err"
     flux_flag_col = f"{flux_col}_flag"
 
-    obj_mag_cols = [f"{band}_psfMag" for band in bands]
-
-    obj_extendedness_cols = [f"{band}_extendedness" for band in bands]
+    # DiaObjects lack per-band psfMag/extendedness object columns; we request the
+    # mean science flux instead and derive both in _normalize_dia_object_columns.
+    if obj == "dia":
+        obj_mag_cols = [f"{band}_scienceFluxMean" for band in bands]
+        obj_extendedness_cols = []
+    else:
+        obj_mag_cols = [f"{band}_psfMag" for band in bands]
+        obj_extendedness_cols = [f"{band}_extendedness" for band in bands]
 
     other_flag_cols = [
         "pixelFlags_suspect",
@@ -428,6 +462,11 @@ def rubin_dp_catalog_multi_band(
         read_visit_cols=True,
     )
 
+    # DiaObjects lack object-level psfMag/extendedness; derive them before the
+    # per-band split that expects those columns.
+    if obj == "dia":
+        catalog = catalog.map_partitions(_normalize_dia_object_columns, bands=bands)
+
     if pre_filter_partition is not None:
         catalog = catalog.map_partitions(pre_filter_partition)
 
@@ -449,5 +488,6 @@ def rubin_dp_catalog_multi_band(
         var_detector=var_detector,
         ccd_visits_path=ccd_visits_path,
         ccd_visits_cols=ccd_visits_cols,
+        require_object_mag=obj != "dia",
     )
     return mapped_catalog

--- a/src/uncle_val/pipelines/train_on_rubin_dp.py
+++ b/src/uncle_val/pipelines/train_on_rubin_dp.py
@@ -62,7 +62,11 @@ def rubin_dp_catalog_and_columns(
         phot=survey_config.phot,
         mode=survey_config.mode,
         pre_filter_partition=pre_filter_partition,
-    ).map_partitions(lambda df: df.drop(columns=["band", "object_mag", "coord_ra", "coord_dec"]))
+    ).map_partitions(
+        # coord_ra/coord_dec exist for the science catalog; the DiaObject catalog
+        # uses ra/dec instead, so ignore missing spatial columns.
+        lambda df: df.drop(columns=["band", "object_mag", "coord_ra", "coord_dec"], errors="ignore")
+    )
 
     lc_fields = list(catalog.dtypes["lc"].column_dtypes)
     flat_columns = [col for col in catalog.columns if col != "lc"]

--- a/src/uncle_val/utils/mag_flux.py
+++ b/src/uncle_val/utils/mag_flux.py
@@ -1,5 +1,7 @@
 import math
 
+import numpy as np
+
 AB_ZP_NJY = 8.9 + 9 * 2.5
 LN10_0_4 = math.log(10) * 0.4
 LG_E_2_5 = 2.5 / math.log(10)
@@ -19,6 +21,25 @@ def mag2flux(mag):
         Flux density in nJy
     """
     return 10 ** (-0.4 * (mag - AB_ZP_NJY))
+
+
+def flux2mag(flux):
+    """Flux density in nJy to AB magnitude convertion
+
+    Parameters
+    ----------
+    flux : array-like
+        Flux density in nJy
+
+    Returns
+    -------
+    mag : array-like
+        AB magnitude; non-positive fluxes yield non-finite values (NaN/inf).
+    """
+    # Non-positive fluxes (faint/artifact objects) give a non-finite magnitude;
+    # silence the expected log10 warning rather than masking the input.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        return AB_ZP_NJY - 2.5 * np.log10(flux)
 
 
 def fluxerr2magerr(*, flux, flux_err):


### PR DESCRIPTION
## Summary

Adds support for the Rubin **DiaObject** catalog so a model trained on the Object catalog can be applied to `diaObjectForcedSource` light curves.

`obj="dia"` opens `dia_object_collection` / `diaObjectForcedSource` (both `img="cal"` psfFlux and `img="diff"` psfDiffFlux). The per-source model features (flux/err, visit-derived `skyBg`/`seeing`/`expTime`, detector geometry, one-hot bands) come through unchanged. The two object-level features DiaObjects lack are handled as:

- **`object_mag`** — derived from `{band}_scienceFluxMean` via the new `flux2mag`; not required for dia (undefined values kept), since it does not affect the whitening.
- **`extendedness`** — set to `0.0` (point-source assumption), with a `TODO` to cross-match the science Object catalog for the real per-object value.

## Changes
- `datasets/rubin_dp.py`: `obj="dia"` branches in `_open_catalog`; `_normalize_dia_object_columns`; relaxed the `object_mag` dropna for dia.
- `utils/mag_flux.py`: add `flux2mag` (inverse of `mag2flux`).
- `pipelines/train_on_rubin_dp.py`: ignore missing `coord_ra`/`coord_dec` (DiaObject uses `ra`/`dec`).
- `scripts/plot_reduced_chi2.py`, `scripts/plot_kl.py`: `--obj`/`--img` overrides.

## Notes
- Verified end-to-end: the DP1 ForcedDiffSource model applied to DiaObject difference-image photometry reconstructs model columns, materializes partitions, and renders the figures.
- Builds on the diagnostic-plot driver scripts introduced in #103 (merged).
